### PR TITLE
added CrackerSuman/Algorithms in the list.

### DIFF
--- a/blacklist/README.md
+++ b/blacklist/README.md
@@ -57,3 +57,4 @@ List of excluded repos that are now invalid towards Hacktoberfest pull requests:
 * [vinitshahdeo/inspirational-quotes](https://github.com/vinitshahdeo/inspirational-quotes)
 * [viralvaghela/hacktoberfest_2021](https://github.com/viralvaghela/hacktoberfest_2021)
 * [yashrajmani/Hacktoberfest2021](https://github.com/yashrajmani/Hacktoberfest2021)
+* [CrackerSuman/Algorithms](https://github.com/CrackerSuman/Algorithms)


### PR DESCRIPTION
As the 'Not-a-Excluded-Project' repo from CrackerSuman is also there in the blacklist.